### PR TITLE
Change _BlurOffset type from half1 to half to support Metal (reproduced with Unity 2022.3.4f1)

### DIFF
--- a/Runtime/Shaders/DualKawaseBlur.hlsl
+++ b/Runtime/Shaders/DualKawaseBlur.hlsl
@@ -4,7 +4,7 @@
 TEXTURE2D_X(_SourceTex);
 SAMPLER(sampler_linear_clamp);
 float4 _SourceTex_TexelSize;
-half1 _BlurOffset;
+half _BlurOffset;
 
 struct MeshData
 {


### PR DESCRIPTION
Likely a Unity issue, but this ultimately fixed the problem on my end. Hope it's helpful to others.